### PR TITLE
Add the Typescript .d.ts documentation

### DIFF
--- a/file-dialog.d.ts
+++ b/file-dialog.d.ts
@@ -1,0 +1,31 @@
+declare module 'popups-file-dialog'
+
+export const openFile: (opts?: {
+    title?: string,
+    startPath?: string,
+    filterPatterns?: Array<string>,
+    filterPatternsDescription?: string,
+    allowMultipleSelects?: boolean
+}) => Promise<Array<string>>
+
+export const openDirectory: (opts?: { title?: string }) => Promise<string>
+
+export type dialogType = "ok" | "okCancel" | "yesNo" | "yesNoCancel"
+export type iconType = "info" | "warning" | "error" | "question"
+export type defaultSelectedButton = "yes" | "no" | "ok" | "cancel"
+export type dialogResult = 0 | 1 | 2
+
+export const messageBox: (opts?: {
+    title?: String,
+    message?: String,
+    dialogType?: dialogType,
+    iconType?: iconType,
+    defaultSelected?: defaultSelectedButton
+}) => Promise<dialogResult>
+
+export const saveFile: (opts?: {
+    title?: string,
+    startPath?: string,
+    filterPatterns?: Array<string>,
+    filterPatternsDescription?: String
+}) => Promise<string>


### PR DESCRIPTION
I added the file [`file-dialog.d.ts`](/eliotttak/popups-file-dialog/blob/master/file-dialog.d.ts) to make the IDEs as VSCode know exactly what are the arguments, and can throw errors if necessary.

For example:
```javascript
fileDialog.openFile({
    title: 1234 // Before file-dialog.d.ts, VSCode would have shown nothing. Now, it shows "Type 'number' is not assignable to type 'string'".
}).then(file => {
    console.log(`You selected : ${file[0]}.`)
}